### PR TITLE
feat: Support Kustomize plugins

### DIFF
--- a/main.go
+++ b/main.go
@@ -410,6 +410,7 @@ func chartifyOptsFromFlags(f *pflag.FlagSet) *helmx.ChartifyOpts {
 	f.StringVar(&chartifyOpts.ChartVersion, "version", "", "specify the exact chart version to use. If this is not specified, the latest version is used")
 
 	f.BoolVar(&chartifyOpts.Debug, "debug", os.Getenv("HELM_X_DEBUG") == "on", "enable verbose output")
+	f.BoolVar(&chartifyOpts.EnableKustomizeAlphaPlugins, "enable_alpha_plugins", false, "Enable the use of kustomize plugins")
 
 	return chartifyOpts
 }

--- a/pkg/helmx/chartify.go
+++ b/pkg/helmx/chartify.go
@@ -33,6 +33,9 @@ type ChartifyOpts struct {
 	// TillerNamespace is the namespace Tiller or Helm v3 creates "release" objects(configmaps or secrets depending on the storage backend chosen)
 	TillerNamespace string
 
+	// EnableKustomizAlphaPlugins will add the `--enable_alpha_goplugins_accept_panic_risk` flag when running `kustomize build`
+	EnableKustomizeAlphaPlugins bool
+
 	Injectors []string
 	Injects   []string
 
@@ -117,6 +120,7 @@ func (r *Runner) Chartify(release, dirOrChart string, opts ...ChartifyOption) (s
 		kustomOpts := &KustomizeBuildOpts{
 			ValuesFiles: u.ValuesFiles,
 			SetValues:   u.SetValues,
+			EnableAlphaPlugins: u.EnableKustomizeAlphaPlugins,
 		}
 		kustomizeFile, err := r.KustomizeBuild(dirOrChart, tempDir, kustomOpts)
 		if err != nil {

--- a/pkg/helmx/kustomize.go
+++ b/pkg/helmx/kustomize.go
@@ -13,6 +13,7 @@ import (
 type KustomizeBuildOpts struct {
 	ValuesFiles []string
 	SetValues   []string
+	EnableAlphaPlugins bool
 }
 
 func (o *KustomizeBuildOpts) SetKustomizeBuildOption(opts *KustomizeBuildOpts) error {
@@ -105,7 +106,11 @@ func (r *Runner) KustomizeBuild(srcDir string, tempDir string, opts ...Kustomize
 		}
 	}
 	kustomizeFile := filepath.Join(tempDir, "kustomized.yaml")
-	out, err := r.Run("kustomize", "-o", kustomizeFile, "build", "--load_restrictor=none", tempDir)
+	kustomizeArgs := []string{"-o", kustomizeFile, "build", "--load_restrictor=none"}
+	if u.EnableAlphaPlugins {
+		kustomizeArgs = append(kustomizeArgs, "--enable_alpha_plugins")
+	}
+	out, err := r.Run("kustomize", append(kustomizeArgs, tempDir)...)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Kustomize had support for Go plugins for a while in the master branch.
With the recent release of Kustomize v2.1.0, plugins are now in alpha.
https://github.com/kubernetes-sigs/kustomize/blob/master/docs/v2.1.0.md#generator-and-transformer-plugins
These changes allow to pass the `--enable_alpha_plugins` flag from
`helm x` to `kustomize`.
By leveraging plugins like https://github.com/Agilicus/kustomize-sops,
secrets can now be encrypted and stored in the repository.